### PR TITLE
Update gitignore and setup.cfg for pycodestyle linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+#VSCode Settings Folder
+.vscode

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,3 +49,7 @@ addopts =
 
 [wheel]
 universal = 1
+
+[pycodestyle]
+ignore = W291, E501, E261, W191, W293
+max-line-length = 120


### PR DESCRIPTION
I added some rules for the PyCodeStyle linter (for those of us who use them anyway 😛 ), and hid my personal .vscode folder with the settings, since the linter settings in setup.cfg should be fine.